### PR TITLE
fix(deps): update geozero to 0.15 and flatgeobuf to v6

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -443,9 +443,9 @@ dependencies = [
 
 [[package]]
 name = "flatgeobuf"
-version = "4.6.0"
+version = "6.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9aa0c2132e1c646a8d636ac582a09dfb593d25c62c4263ed021e0af56f4db7b"
+checksum = "440aaa920020917f3d52b61d82f871d945d9707cbec6c33a5c55a2d85b385121"
 dependencies = [
  "byteorder",
  "bytes",
@@ -540,9 +540,9 @@ dependencies = [
 
 [[package]]
 name = "geo-traits"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b018fc19fa58202b03f1c809aebe654f7d70fd3887dace34c3d05c11aeb474b5"
+checksum = "2e7c353d12a704ccfab1ba8bfb1a7fe6cb18b665bf89d37f4f7890edcd260206"
 dependencies = [
  "geo-types",
 ]
@@ -584,15 +584,15 @@ dependencies = [
 
 [[package]]
 name = "geozero"
-version = "0.14.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5f28f34864745eb2f123c990c6ffd92c1584bd39439b3f27ff2a0f4ea5b309b"
+checksum = "db5eda63aa99ac06160fd53328ed75c34f14e3196d3f56a3649e247ed796e54b"
 dependencies = [
  "geo-types",
  "geojson",
  "log",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.18",
  "wkt",
 ]
 
@@ -1716,7 +1716,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.4.2",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -2289,10 +2289,11 @@ dependencies = [
 
 [[package]]
 name = "wkt"
-version = "0.11.1"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54f7f1ff4ea4c18936d6cd26a6fd24f0003af37e951a8e0e8b9e9a2d0bd0a46d"
+checksum = "efb2b923ccc882312e559ffaa832a055ba9d1ac0cc8e86b3e25453247e4b81d7"
 dependencies = [
+ "geo-traits",
  "geo-types",
  "log",
  "num-traits",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,8 +36,8 @@ indicatif = "0.18"
 zip = "8.0"
 shapefile = { version = "0.7", optional = true }
 rusqlite = { version = "0.39", features = ["bundled"], optional = true }
-flatgeobuf = { version = "4.3", optional = true }
-geozero = { version = "0.14", optional = true }
+flatgeobuf = { version = "6.0", optional = true }
+geozero = { version = "0.15", optional = true }
 
 [dev-dependencies]
 tempfile = "3"


### PR DESCRIPTION
## Summary

- Updates `geozero` from 0.14 → 0.15 and `flatgeobuf` from 4.3 → 6.0 in a single combined commit
- Combines Renovate PRs #20 and #28, which must be updated together because `flatgeobuf` v6 depends on `geozero` 0.15 — updating either crate in isolation splits the dep tree and causes E0277/E0599 trait-bound compilation failures
- No application code changes were required; only `Cargo.toml` version constraints changed

## Why these must move together

`flatgeobuf` 4.x depends on `geozero` 0.14. If `geozero` is bumped to 0.15 while `flatgeobuf` stays at 4.x, Cargo resolves two separate `geozero` versions. Rust trait implementations from one version are not compatible with bounds from the other (even if structurally identical), producing errors like:

```
error[E0277]: the trait bound `PropCollector: flatgeobuf::geozero::PropertyProcessor` is not satisfied
```

`flatgeobuf` v6 bumps its own `geozero` dependency to 0.15, so both crates now share a single resolved version.

## Test plan

- [x] `cargo build` succeeds with no errors
- [x] `cargo test --all-features` — 92 unit tests + 17 integration tests all pass
- [x] `cargo clippy --all-targets --all-features -- -D warnings` clean (using pinned `1.93.1` toolchain)

Closes #20, closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)